### PR TITLE
Use &Path instead of PathBuf

### DIFF
--- a/src/cmd/make_db.rs
+++ b/src/cmd/make_db.rs
@@ -15,7 +15,7 @@ pub struct Opts {
 }
 
 pub fn run(op: &Opts) -> Result<()> {
-    let gtfs_csv = external::gtfscsv::init(op.gtfs_dir.clone())?;
+    let gtfs_csv = external::gtfscsv::init(&op.gtfs_dir)?;
     let gtfs_db = external::gtfsdb::init(&op.database)?;
 
     let mut service = GtfsService::new(gtfs_db, gtfs_csv);

--- a/src/external/gtfscsv.rs
+++ b/src/external/gtfscsv.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 
@@ -23,14 +23,14 @@ pub struct GtfsCsv {
     gtfs_dir: PathBuf,
 }
 
-pub fn init(path: PathBuf) -> Result<Box<dyn Gtfs>> {
+pub fn init(path: &Path) -> Result<Box<dyn Gtfs>> {
     let ins = GtfsCsv::new(path)?;
     Ok(Box::new(ins))
 }
 
 impl GtfsCsv {
-    pub fn new(gtfs_dir: PathBuf) -> Result<Self> {
-        Ok(GtfsCsv { gtfs_dir })
+    pub fn new(gtfs_dir: &Path) -> Result<Self> {
+        Ok(GtfsCsv { gtfs_dir: gtfs_dir.into() })
     }
 }
 

--- a/src/external/gtfsdb.rs
+++ b/src/external/gtfsdb.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::Path;
 
 use anyhow::{Context, Result};
 use log::{debug, trace};
@@ -32,7 +32,7 @@ pub trait Table {
     fn create_sql() -> &'static str;
 }
 
-pub fn init(path: &PathBuf) -> Result<Box<dyn Gtfs>> {
+pub fn init(path: &Path) -> Result<Box<dyn Gtfs>> {
     let ins = GtfsDb::new(path)?;
     Ok(Box::new(ins))
 }
@@ -104,9 +104,8 @@ where
 }
 
 impl GtfsDb {
-    pub fn new(db: &PathBuf) -> Result<Self> {
-        let db_file = db.to_str().unwrap();
-        let conn = Connection::open(db_file)?;
+    pub fn new(db: &Path) -> Result<Self> {
+        let conn = Connection::open(db)?;
 
         Ok(GtfsDb { connection: conn })
     }


### PR DESCRIPTION
関数の引数で使用する型は所有型 (`String, PathBuf`) ではなく参照型 (`&str, &Path`) を使用したほうが良いのでそのように変更しました。

```rust
pub struct GtfsCsv {
    gtfs_dir: PathBuf,
}
```

の `gtfs_dir` へのクローンをやめたければ

```rust
pub struct GtfsCsv<'a> {
    gtfs_dir: &'a Path,
}
```

のように変更すればいいのですが `GtfsCsv` のメンバの生存期間をどのように管理したいかは
ポリシーの問題のような気がするので現状のままにしてあります。