### PR TITLE
Use generics instead of Box<dyn T>

### DIFF
--- a/src/app/gtfs.rs
+++ b/src/app/gtfs.rs
@@ -5,17 +5,22 @@ use log::info;
 use crate::external;
 use std::path::PathBuf;
 
-pub struct GtfsService {
-    gtfs_db: Box<dyn external::gtfs::Gtfs>,
-    gtfs_csv: Box<dyn external::gtfs::Gtfs>,
+pub struct GtfsService<G1, G2>
+where
+    G1: external::gtfs::Gtfs,
+    G2: external::gtfs::Gtfs,
+{
+    gtfs_db: G1,
+    gtfs_csv: G2,
 }
 
 /// GTFS全体を横断するアプリケーションサービス
-impl GtfsService {
-    pub fn new(
-        gtfs_db: Box<dyn external::gtfs::Gtfs>,
-        gtfs_csv: Box<dyn external::gtfs::Gtfs>,
-    ) -> Self {
+impl<G1, G2> GtfsService<G1, G2>
+where
+    G1: external::gtfs::Gtfs,
+    G2: external::gtfs::Gtfs,
+{
+    pub fn new(gtfs_db: G1, gtfs_csv: G2) -> Self {
         Self { gtfs_db, gtfs_csv }
     }
 

--- a/src/app/route.rs
+++ b/src/app/route.rs
@@ -3,12 +3,18 @@ use anyhow::Result;
 use crate::external;
 use crate::external::gtfs::routes::Route;
 
-pub struct RouteService {
-    gtfs: Box<dyn external::gtfs::Gtfs>,
+pub struct RouteService<G>
+where
+    G: external::gtfs::Gtfs,
+{
+    gtfs: G,
 }
 
-impl RouteService {
-    pub fn new(gtfs: Box<dyn external::gtfs::Gtfs>) -> Self {
+impl<G> RouteService<G>
+where
+    G: external::gtfs::Gtfs,
+{
+    pub fn new(gtfs: G) -> Self {
         Self { gtfs }
     }
 

--- a/src/app/test.rs
+++ b/src/app/test.rs
@@ -3,14 +3,20 @@ use anyhow::Result;
 use crate::external;
 use crate::external::gtfs::shapes::Shape;
 
-pub struct TestService {
-    gtfs: Box<dyn external::gtfs::Gtfs>,
+pub struct TestService<G>
+where
+    G: external::gtfs::Gtfs,
+{
+    gtfs: G,
 }
 
 /// 開発動作確認用に好きな操作をさせるService
 /// プロダクションでも使うコマンドは別途きちんと作成すること
-impl TestService {
-    pub fn new(gtfs: Box<dyn external::gtfs::Gtfs>) -> Self {
+impl<G> TestService<G>
+where
+    G: external::gtfs::Gtfs,
+{
+    pub fn new(gtfs: G) -> Self {
         Self { gtfs }
     }
 

--- a/src/app/trip.rs
+++ b/src/app/trip.rs
@@ -3,12 +3,18 @@ use anyhow::Result;
 use crate::external;
 use crate::external::gtfs::trips::Trip;
 
-pub struct TripService {
-    gtfs: Box<dyn external::gtfs::Gtfs>,
+pub struct TripService<G>
+where
+    G: external::gtfs::Gtfs,
+{
+    gtfs: G,
 }
 
-impl TripService {
-    pub fn new(gtfs: Box<dyn external::gtfs::Gtfs>) -> Self {
+impl<G> TripService<G>
+where
+    G: external::gtfs::Gtfs,
+{
+    pub fn new(gtfs: G) -> Self {
         Self { gtfs }
     }
 

--- a/src/external/gtfscsv.rs
+++ b/src/external/gtfscsv.rs
@@ -23,9 +23,8 @@ pub struct GtfsCsv {
     gtfs_dir: PathBuf,
 }
 
-pub fn init(path: &Path) -> Result<Box<dyn Gtfs>> {
-    let ins = GtfsCsv::new(path)?;
-    Ok(Box::new(ins))
+pub fn init(path: &Path) -> Result<GtfsCsv> {
+    GtfsCsv::new(path)
 }
 
 impl GtfsCsv {

--- a/src/external/gtfsdb.rs
+++ b/src/external/gtfsdb.rs
@@ -32,9 +32,8 @@ pub trait Table {
     fn create_sql() -> &'static str;
 }
 
-pub fn init(path: &Path) -> Result<Box<dyn Gtfs>> {
-    let ins = GtfsDb::new(path)?;
-    Ok(Box::new(ins))
+pub fn init(path: &Path) -> Result<GtfsDb> {
+    GtfsDb::new(path)
 }
 
 pub fn create<T>(conn: &Connection) -> Result<()>


### PR DESCRIPTION
`Box<dyn T>` が有効活用できるのは関数から返却される型が条件文などによって動的に変わるケースのみで
コンパイル時に型が特定できる場合はジェネリクスを使ったほうが安全なんじゃないかと思いました。

少し気になったのが各 `Service` 構造体が `gtfs` の所有権を持っていると
同時に複数の `Service` 構造体のインスタンスが作成できなくなるので
参照型を持たせるか `Rc<T>` または `Arc<T>` に変えるかしないといけないんじゃないかなぁということです。
これはジェネリクスを使わずに動的にディスパッチする場合も同じ考慮が必要になってきます。

[Rustの `Arc` を読む(1): Arc/Rcの基本 - Qiita](https://qiita.com/qnighy/items/4bbbb20e71cf4ae527b9)